### PR TITLE
Ssl Connection refactor

### DIFF
--- a/configuration.rb
+++ b/configuration.rb
@@ -7,7 +7,7 @@ class Configuration
   attr_reader :config
 
   def initialize
-    @config = YAML.load(ERB.new(File.read(CONFIG_PATH)).result).freeze
+    @config = YAML.safe_load(ERB.new(File.read(CONFIG_PATH)).result).freeze
   end
 
   def [](key)

--- a/lib/departure/connection/ssl.rb
+++ b/lib/departure/connection/ssl.rb
@@ -1,0 +1,42 @@
+module Departure
+  module Connection
+    class Ssl
+      ENABLED_MODES = %i[preferred required verify_ca verify_identity].freeze
+
+      def initialize(connection_data)
+        @connection_data = connection_data
+      end
+
+      def ssl_arguments
+        return '' unless ssl_mode_enabled?
+
+        ssl = ';mysql_ssl=1'
+        ssl += ";mysql_ssl_client_ca=#{ssl_ca}" if ssl_ca.present?
+
+        ssl
+      end
+
+      private
+
+      attr_reader :connection_data
+
+      def ssl_mode_enabled?
+        ENABLED_MODES.include? ssl_mode
+      end
+
+      # Returns the database' SSL mode.
+      #
+      # @return [String]
+      def ssl_mode
+        connection_data.fetch(:ssl_mode, :disable)
+      end
+
+      # Returns the database' SSL CA certificate.
+      #
+      # @return [String]
+      def ssl_ca
+        connection_data.fetch(:sslca, nil)
+      end
+    end
+  end
+end

--- a/lib/departure/connection_details.rb
+++ b/lib/departure/connection_details.rb
@@ -88,7 +88,7 @@ module Departure
 
     # Returns the database's ssl.
     #
-    # @return [String]
+    # @return [Departure::Connection::Ssl]
     def ssl_connection
       @ssl_connection ||= Departure::Connection::Ssl.new(connection_data)
     end

--- a/lib/departure/connection_details.rb
+++ b/lib/departure/connection_details.rb
@@ -1,3 +1,4 @@
+require 'departure/connection/ssl'
 require 'shellwords'
 module Departure
   # Holds the parameters of the DB connection and formats them to string
@@ -45,9 +46,8 @@ module Departure
     # @return [String]
     def host_argument
       host_string = host
-      if ssl_ca.present?
-        host_string += ";mysql_ssl=1;mysql_ssl_client_ca=#{ssl_ca}"
-      end
+      host_string += ssl_connection.ssl_arguments
+
       "-h \"#{host_string}\""
     end
 
@@ -86,11 +86,11 @@ module Departure
       connection_data.fetch(:port, DEFAULT_PORT)
     end
 
-    # Returns the database' SSL CA certificate.
+    # Returns the database's ssl.
     #
     # @return [String]
-    def ssl_ca
-      connection_data.fetch(:sslca, nil)
+    def ssl_connection
+      @ssl_connection ||= Departure::Connection::Ssl.new(connection_data)
     end
   end
 end

--- a/spec/departure/connection/ssl_spec.rb
+++ b/spec/departure/connection/ssl_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Departure::Connection::Ssl do
+  let(:ssl_connection) { described_class.new(connection_data) }
+
+  describe '#ssl_arguments' do
+    subject { ssl_connection.ssl_arguments }
+
+    context 'when the ssl_mode is not set' do
+      let(:connection_data) { {} }
+      it { is_expected.to match('') }
+    end
+
+    context 'when the ssl_mode is disable' do
+      context 'without other ssl configuration' do
+        let(:connection_data) { { ssl_mode: :disabled } }
+
+        it { is_expected.to match('') }
+      end
+
+      context 'with ssl configuration' do
+        let(:connection_data) { { ssl_mode: :disabled, sslca: '~/test.pem' } }
+
+        it { is_expected.to match('') }
+      end
+    end
+
+    context 'when the ssl_mode is enabled' do
+      context 'without other ssl configuration' do
+        let(:connection_data) { { ssl_mode: :required } }
+
+        it { is_expected.to match(';mysql_ssl=1') }
+      end
+
+      context 'with ssl configuration' do
+        let(:connection_data) { { ssl_mode: :required, sslca: '~/test.pem' } }
+
+        it { is_expected.to match(';mysql_ssl=1;mysql_ssl_client_ca=~/test.pem') }
+      end
+    end
+  end
+end

--- a/spec/departure/connection_details_spec.rb
+++ b/spec/departure/connection_details_spec.rb
@@ -50,7 +50,7 @@ describe Departure::ConnectionDetails do
 
       context 'when ssl ca is specified' do
         let(:connection_data) do
-          { host: 'foo.com:3306', user: 'root', database: 'dummy_test', sslca: '~/test.pem' }
+          { host: 'foo.com:3306', user: 'root', database: 'dummy_test', ssl_mode: :verify_ca, sslca: '~/test.pem' }
         end
         it { is_expected.to include('-h "foo.com:3306;mysql_ssl=1;mysql_ssl_client_ca=~/test.pem"') }
       end

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -50,21 +50,21 @@ describe Departure, integration: true do
     end
 
     it 'when foreign key has a custom name' do
-      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "fk_123456")
+      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: 'fk_123456')
 
       ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
     end
 
     it 'when foreign key has a custom name prefixed with _' do
-      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "_fk_123456")
+      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: '_fk_123456')
 
       ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
     end
 
     it 'when foreign key has a custom name prefixed with __ (double _)' do
-      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "__fk_123456")
+      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: '__fk_123456')
 
       ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')

--- a/spec/integration/indexes_spec.rb
+++ b/spec/integration/indexes_spec.rb
@@ -119,7 +119,7 @@ describe Departure, integration: true do
       let(:direction) { :up }
 
       before do
-        ActiveRecord::Migrator.new(:up, migration_fixtures, ActiveRecord::SchemaMigration,1).migrate
+        ActiveRecord::Migrator.new(:up, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
       end
 
       it 'executes the percona command' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,7 +68,7 @@ module Rails5Compatibility
   end
 
   module MigrationContext
-    def initialize(migrations_paths, schema_migration = nil)
+    def initialize(migrations_paths, _schema_migration = nil)
       super(migrations_paths)
     end
   end


### PR DESCRIPTION
This PR prevents the need for `sslca` presence to enable the SSL connection.

We linked the Ssl Connection enabling with the [ssl_mode option](https://github.com/PWNHealth/departure) where when it's null or disabled, we should not enabled the connection.

PS.: Some of the changes were the rubocop offenses fix